### PR TITLE
ノーツが正常に処理されない不具合の修正

### DIFF
--- a/Alhythm/src/Game_Object_Lane.cpp
+++ b/Alhythm/src/Game_Object_Lane.cpp
@@ -81,10 +81,11 @@ std::deque<NoteJudge> Lane::Update(){
 			if( !note.IsValidToIndicate() ){
 				break;
 			}
-			note.Update();
+			note.UpdatePos();
 		}
 
 		// 処理終わったノーツをポップ
+		line.second.front().UpdateJudging();
 		NoteJudge res = line.second.front().Result();
 		if( res != NoteJudge::Undone ){
 			line.second.pop_front();

--- a/Alhythm/src/Game_Object_Note.cpp
+++ b/Alhythm/src/Game_Object_Note.cpp
@@ -84,13 +84,7 @@ Game::Object::Note::Note(){}
 
 Game::Object::Note::~Note(){}
 
-void Game::Object::Note::Update(){
-	// ノーツの位置更新
-	timeDiff = secOnMusic - track->CurSec();
-	if( 0.0 < timeDiff && timeDiff < NOTE_INDICATE_TIME ){
-		noteRect.setPos( { rectPosX, JUDGELINE_HEGHT - static_cast<int>( ( timeDiff / NOTE_INDICATE_TIME ) * JUDGELINE_HEGHT ) } );
-	}
-
+void Game::Object::Note::UpdateJudging(){
 	// このノーツが通り過ぎてない&&判定される秒数内ならば
 	if( tapResult == NoteJudge::Undone && secOnMusic - MISS_TIME < track->CurSec() && track->CurSec() < secOnMusic + MISS_TIME ){
 		isPushable = true;
@@ -116,6 +110,13 @@ void Game::Object::Note::Update(){
 	}
 	else if( isPushable && timeDiff < -MISS_TIME ){ // ノーツが押されなかったが通り過ぎた
 		tapResult = NoteJudge::Miss;
+	}
+}
+
+void Game::Object::Note::UpdatePos(){
+	timeDiff = secOnMusic - track->CurSec();
+	if( 0.0 < timeDiff && timeDiff < NOTE_INDICATE_TIME ){
+		noteRect.setPos( { rectPosX, JUDGELINE_HEGHT - static_cast< int >( ( timeDiff / NOTE_INDICATE_TIME ) * JUDGELINE_HEGHT ) } );
 	}
 }
 

--- a/Alhythm/src/Game_Object_Note.h
+++ b/Alhythm/src/Game_Object_Note.h
@@ -1,4 +1,5 @@
 ﻿#pragma once
+#pragma once
 
 #define NO_S3D_USING
 
@@ -22,7 +23,8 @@ public:
 	Note();
 	~Note();
 
-	void Update();
+	void UpdateJudging();
+	void UpdatePos();
 	void Draw() const;
 
 	// ノーツの判定を返す


### PR DESCRIPTION
前の(先頭の)ノーツが未処理でもそのあとのノーツがボタン押下で判定されてしまう不具合を修正しました。